### PR TITLE
Rename oe_id to taxonomy_id

### DIFF
--- a/source/includes/_categories.md
+++ b/source/includes/_categories.md
@@ -23,28 +23,28 @@ curl "https://ohana-api-demo.herokuapp.com/api/categories" -H "User-Agent: MyCli
   {
     "id": 1,
     "depth": 0,
-    "oe_id": "101",
+    "taxonomy_id": "101",
     "name": "Emergency",
     "parent_id": null
   },
   {
     "id": 2,
     "depth": 1,
-    "oe_id": "101-01",
+    "taxonomy_id": "101-01",
     "name": "Disaster Response",
     "parent_id": 1
   },
   {
     "id": 3,
     "depth": 1,
-    "oe_id": "101-02",
+    "taxonomy_id": "101-02",
     "name": "Emergency Cash",
     "parent_id": 1
   },
   {
     "id": 4,
     "depth": 2,
-    "oe_id": "101-02-01",
+    "taxonomy_id": "101-02-01",
     "name": "Help Pay for Food",
     "parent_id": 3
   }

--- a/source/includes/_get_category_children.md
+++ b/source/includes/_get_category_children.md
@@ -6,12 +6,12 @@ Ohanakapa.configure do |c|
   c.api_endpoint = 'https://ohana-api-demo.herokuapp.com/api'
 end
 
-# Fetch all children of the category with a specific `oe_id`.
-Ohanakapa.get('categories/:category_oe_id/children')
+# Fetch all children of the category with a specific `taxonomy_id`.
+Ohanakapa.get('categories/:category_taxonomy_id/children')
 ```
 
 ```shell
-# Fetch all children of the category with a specific `oe_id`.
+# Fetch all children of the category with a specific `taxonomy_id`.
 
 curl "https://ohana-api-demo.herokuapp.com/api/categories/101/children" -H "User-Agent: MyClient/1.0.0"
 ```
@@ -23,49 +23,49 @@ curl "https://ohana-api-demo.herokuapp.com/api/categories/101/children" -H "User
   {
     "id":2,
     "depth":1,
-    "oe_id":"101-01",
+    "taxonomy_id":"101-01",
     "name":"Disaster Response",
     "parent_id":1
   },
   {
     "id":3,
     "depth":1,
-    "oe_id":"101-02",
+    "taxonomy_id":"101-02",
     "name":"Emergency Cash",
     "parent_id":1
   },
   {
     "id":10,
     "depth":1,
-    "oe_id":"101-03",
+    "taxonomy_id":"101-03",
     "name":"Emergency Food",
     "parent_id":1
   },
   {
    "id":11,
    "depth":1,
-   "oe_id":"101-04",
+   "taxonomy_id":"101-04",
    "name":"Emergency Shelter",
    "parent_id":1
   },
   {
     "id":12,
     "depth":1,
-    "oe_id":"101-05",
+    "taxonomy_id":"101-05",
     "name":"Help Find Missing Persons",
     "parent_id":1
   },
   {
     "id":13,
     "depth":1,
-    "oe_id":"101-06",
+    "taxonomy_id":"101-06",
     "name":"Immediate Safety",
     "parent_id":1
   },
   {
     "id":16,
     "depth":1,
-    "oe_id":"101-07",
+    "taxonomy_id":"101-07",
     "name":"Psychiatric Emergency Services",
     "parent_id":1
   }
@@ -76,4 +76,4 @@ This endpoint retrieves all children categories of a specific category.
 
 ### HTTP Request
 
-`GET https://ohana-api-demo.herokuapp.com/api/categories/:category_oe_id/children`
+`GET https://ohana-api-demo.herokuapp.com/api/categories/:category_taxonomy_id/children`

--- a/source/includes/_update_service_categories.md
+++ b/source/includes/_update_service_categories.md
@@ -2,15 +2,15 @@
 
 ```ruby
 # Update categories for the service with id 1 by passing in an array of
-# oe_ids.
-Ohanakapa.put('services/1/categories', { oe_ids: ['101', '102'] })
+# taxonomy_ids.
+Ohanakapa.put('services/1/categories', { taxonomy_ids: ['101', '102'] })
 ```
 
 ```shell
 # Update categories for the service with id 1 by passing in an array of
-# oe_ids.
+# taxonomy_ids.
 
-curl -X PUT "https://ohana-api-demo.herokuapp.com/api/services/1/categories" -d '{"oe_ids": ["101", "102"]}' -H "X-Api-Token: your_token" -H "Content-Type: application/json"
+curl -X PUT "https://ohana-api-demo.herokuapp.com/api/services/1/categories" -d '{"taxonomy_ids": ["101", "102"]}' -H "X-Api-Token: your_token" -H "Content-Type: application/json"
 ```
 
 > When successful, the above command returns the updated service with a `200` HTTP status code:
@@ -40,14 +40,14 @@ curl -X PUT "https://ohana-api-demo.herokuapp.com/api/services/1/categories" -d 
     {
       "id": 1,
       "depth": 0,
-      "oe_id": "101",
+      "taxonomy_id": "101",
       "name": "Emergency",
       "parent_id": null
     },
     {
       "id": 17,
       "depth": 0,
-      "oe_id": "102",
+      "taxonomy_id": "102",
       "name": "Food",
       "parent_id": null
     }
@@ -65,7 +65,7 @@ This endpoint updates a service with the specified categories.
 
 | Name | Type | Requirement | Detail |
 |:-----|:-----|:---------|:-------|
-| oe_ids | Array | required | An array of valid `oe_id`s. |
+| taxonomy_ids | Array | required | An array of valid `taxonomy_id`s. |
 
 <aside class="warning">All PUT requests require a valid token passed via the
 `X-Api-Token` HTTP header</aside>


### PR DESCRIPTION
The field was renamed a while back in the API but the documentation hadn't been updated.

Closes #2.